### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/prefix-dev/archspec-rs/compare/archspec-v0.1.3...archspec-v0.1.4) - 2025-03-24
+
+### Other
+
+- bump archspec-json ([#11](https://github.com/prefix-dev/archspec-rs/pull/11))
+- update README ([#10](https://github.com/prefix-dev/archspec-rs/pull/10))
+
 ## [0.1.3](https://github.com/prefix-dev/archspec-rs/compare/v0.1.2...v0.1.3) - 2024-03-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [ "bin"]
 
 [package]
 name = "archspec"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Bas Zalmstra <bas@prefix.dev>", "Lars Viklund <zao@zao.se>"]
 description = "Provides standardized human-readable labels for aspects and capabilities of a system"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `archspec`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/prefix-dev/archspec-rs/compare/archspec-v0.1.3...archspec-v0.1.4) - 2025-03-24

### Other

- bump archspec-json ([#11](https://github.com/prefix-dev/archspec-rs/pull/11))
- update README ([#10](https://github.com/prefix-dev/archspec-rs/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).