### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/archspec/archspec-rs/compare/archspec-v0.1.3...archspec-v0.2.0) - 2026-03-06
+
+### Fixed
+
+- take cpu_part into account ([#13](https://github.com/archspec/archspec-rs/pull/13))
+- rename depandabot.yml to dependabot.yml ([#14](https://github.com/archspec/archspec-rs/pull/14))
+- compiler issue
+
+### Other
+
+- *(ci)* update release-plz workflow ([#17](https://github.com/archspec/archspec-rs/pull/17))
+- add msrv ([#18](https://github.com/archspec/archspec-rs/pull/18))
+- bump json to 0.2.5
+- add dependabot for json
+- bump archspec-json ([#11](https://github.com/archspec/archspec-rs/pull/11))
+- update README ([#10](https://github.com/archspec/archspec-rs/pull/10))
+- add basic example ([#8](https://github.com/archspec/archspec-rs/pull/8))
+
 ## [0.1.3](https://github.com/prefix-dev/archspec-rs/compare/v0.1.2...v0.1.3) - 2024-03-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [ "bin"]
 
 [package]
 name = "archspec"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Bas Zalmstra <bas@prefix.dev>", "Lars Viklund <zao@zao.se>"]
 description = "Provides standardized human-readable labels for aspects and capabilities of a system"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `archspec`: 0.1.3 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `archspec` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Microarchitecture.cpupart in /tmp/.tmpZbfh6i/archspec-rs/src/schema/microarchitecture.rs:50
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/archspec/archspec-rs/compare/archspec-v0.1.3...archspec-v0.2.0) - 2026-03-06

### Fixed

- take cpu_part into account ([#13](https://github.com/archspec/archspec-rs/pull/13))
- rename depandabot.yml to dependabot.yml ([#14](https://github.com/archspec/archspec-rs/pull/14))
- compiler issue

### Other

- *(ci)* update release-plz workflow ([#17](https://github.com/archspec/archspec-rs/pull/17))
- add msrv ([#18](https://github.com/archspec/archspec-rs/pull/18))
- bump json to 0.2.5
- add dependabot for json
- bump archspec-json ([#11](https://github.com/archspec/archspec-rs/pull/11))
- update README ([#10](https://github.com/archspec/archspec-rs/pull/10))
- add basic example ([#8](https://github.com/archspec/archspec-rs/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).