### PR TITLE
chore: bump archspec-json to v0.2.6

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -55,8 +55,8 @@ jobs:
           - { name: "Linux-riscv64gc",    target: riscv64gc-unknown-linux-gnu, os: ubuntu-latest }
           - { name: "Linux-s390x",        target: s390x-unknown-linux-gnu, os: ubuntu-latest }
 
-          - { name: "macOS",              target: x86_64-apple-darwin,        os: macOS-latest }
-          - { name: "macOS-arm",          target: aarch64-apple-darwin,       os: macOS-14 }
+          - { name: "macOS",              target: x86_64-apple-darwin,        os: macos-15 }
+          - { name: "macOS-arm",          target: aarch64-apple-darwin,       os: macos-15 }
 
           - { name: "Windows-x86_64",     target: x86_64-pc-windows-msvc,     os: windows-latest }
     steps:

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -65,6 +65,10 @@ jobs:
         with:
           submodules: true
 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 include = ["src/*", "json/cpu/*.json"]
 readme = "README.md"
 repository = "https://github.com/prefix-dev/archspec-rs"
-rust-version = "1.78.0"
+rust-version = "1.85.1"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/cpu/detect.rs
+++ b/src/cpu/detect.rs
@@ -169,10 +169,12 @@ fn detect_linux(arch: &str, cpu_info: &ProcCpuInfo) -> Microarchitecture {
             }
         }
         "riscv64" => {
-            let uarch = match cpu_info.get("uarch") {
-                Some("sifive,u74-mc") => "u74mc",
-                Some(uarch) => uarch,
-                None => "riscv64",
+            let uarch = match (cpu_info.get("uarch"), cpu_info.get("model name")) {
+                (Some("sifive,u74-mc"), _) => "u74mc",
+                (Some("spacemit,x60"), _) => "x60",
+                (_, Some("Spacemit(R) X60")) => "x60",
+                (Some(uarch), _) => uarch,
+                (None, _) => "riscv64",
             };
             Microarchitecture::generic(uarch)
         }
@@ -214,21 +216,30 @@ fn detect_macos<S: SysCtlProvider>(arch: &str, sysctl: &S) -> Microarchitecture 
                 .sysctl("machdep.cpu.leaf7_features")
                 .unwrap_or_default()
                 .to_lowercase();
+            let cpu_extfeatures = sysctl
+                .sysctl("machdep.cpu.extfeatures")
+                .unwrap_or_default()
+                .to_lowercase();
             let vendor = sysctl.sysctl("machdep.cpu.vendor").unwrap_or_default();
 
             let mut features = cpu_features
                 .split_whitespace()
                 .chain(cpu_leaf7_features.split_whitespace())
+                .chain(cpu_extfeatures.split_whitespace())
                 .map(|s| s.to_string())
                 .collect::<HashSet<String>>();
 
-            // Flags detected on Darwin turned to their linux counterpart.
+            // Flags detected on Darwin turned to their linux counterpart. Keys may be a
+            // space separated list of tokens that all need to be present in `features`.
             for (darwin_flag, linux_flag) in crate::schema::MicroarchitecturesSchema::schema()
                 .conversions
                 .darwin_flags
                 .iter()
             {
-                if features.contains(darwin_flag) {
+                if darwin_flag
+                    .split_whitespace()
+                    .all(|token| features.contains(token))
+                {
                     features.extend(linux_flag.split_whitespace().map(|s| s.to_string()))
                 }
             }
@@ -240,16 +251,38 @@ fn detect_macos<S: SysCtlProvider>(arch: &str, sysctl: &S) -> Microarchitecture 
             }
         }
         _ => {
-            let model = match sysctl
+            let brand = sysctl
                 .sysctl("machdep.cpu.brand_string")
-                .map(|v| v.to_string().to_lowercase())
-                .ok()
-            {
-                Some(model) if model.contains("m2") => String::from("m2"),
-                Some(model) if model.contains("m1") => String::from("m1"),
-                Some(model) if model.contains("apple") => String::from("m1"),
-                _ => String::from("unknown"),
-            };
+                .unwrap_or_default()
+                .to_lowercase();
+
+            // Match `apple m<N>`, then walk down until a known target is found in the schema,
+            // matching the upstream Python detection logic.
+            let known_targets = Microarchitecture::known_targets();
+            let model = brand
+                .split_whitespace()
+                .skip_while(|token| *token != "apple")
+                .nth(1)
+                .and_then(|token| token.strip_prefix('m'))
+                .and_then(|digits| {
+                    let n_end = digits
+                        .find(|c: char| !c.is_ascii_digit())
+                        .unwrap_or(digits.len());
+                    digits[..n_end].parse::<u32>().ok()
+                })
+                .and_then(|max_n| {
+                    (1..=max_n)
+                        .rev()
+                        .map(|n| format!("m{}", n))
+                        .find(|candidate| known_targets.contains_key(candidate))
+                })
+                .unwrap_or_else(|| {
+                    if brand == "apple processor" {
+                        String::from("m1")
+                    } else {
+                        String::from("aarch64")
+                    }
+                });
 
             Microarchitecture {
                 vendor: String::from("Apple"),

--- a/src/cpuid.rs
+++ b/src/cpuid.rs
@@ -56,7 +56,7 @@ impl CpuIdProvider for MachineCpuIdProvider {
     fn cpuid(&self, leaf: u32, sub_leaf: u32) -> CpuIdRegisters {
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "x86_64")] {
-                unsafe { std::arch::x86_64::__cpuid_count(leaf, sub_leaf).into() }
+                std::arch::x86_64::__cpuid_count(leaf, sub_leaf).into()
             } else if #[cfg(target_arch = "x86")] {
                 unsafe { std::arch::x86::__cpuid_count(leaf, sub_leaf).into() }
             } else {

--- a/src/cpuid.rs
+++ b/src/cpuid.rs
@@ -54,13 +54,18 @@ pub(crate) struct MachineCpuIdProvider {}
 
 impl CpuIdProvider for MachineCpuIdProvider {
     fn cpuid(&self, leaf: u32, sub_leaf: u32) -> CpuIdRegisters {
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "x86_64")] {
-                std::arch::x86_64::__cpuid_count(leaf, sub_leaf).into()
-            } else if #[cfg(target_arch = "x86")] {
-                unsafe { std::arch::x86::__cpuid_count(leaf, sub_leaf).into() }
-            } else {
-                unimplemented!("Unsupported architecture for CPUID instruction ({leaf} {sub_leaf})")
+        // `__cpuid_count` is `unsafe` on MSRV but became safe in a later Rust release; allow
+        // the resulting `unused_unsafe` warning so the same code builds on both.
+        #[allow(unused_unsafe)]
+        {
+            cfg_if::cfg_if! {
+                if #[cfg(target_arch = "x86_64")] {
+                    unsafe { std::arch::x86_64::__cpuid_count(leaf, sub_leaf).into() }
+                } else if #[cfg(target_arch = "x86")] {
+                    unsafe { std::arch::x86::__cpuid_count(leaf, sub_leaf).into() }
+                } else {
+                    unimplemented!("Unsupported architecture for CPUID instruction ({leaf} {sub_leaf})")
+                }
             }
         }
     }


### PR DESCRIPTION
Updates the vendored archspec-json submodule from v0.2.5 to v0.2.6, which adds Apple M3/M4, AmpereOne, AmpereOne A, SpacemiT X60 and the armv8.6a microarchitectures.

The new data also tightened a few existing microarchitectures (e.g. Haswell now requires lahf_lm/abm/cx16/xsave), which exposed several detection gaps. To keep the test suite green and align with the upstream Python implementation:

- Read machdep.cpu.extfeatures on macOS x86_64 and handle multi-token keys (such as "popcnt lzcnt") in the darwin_flags conversion table.
- Extend Apple Silicon detection to recognise any Apple M<N> brand string, falling back to the closest known M-series target.
- Detect SpacemiT X60 on RISC-V via the uarch or model name field.